### PR TITLE
Including chat.js in proj

### DIFF
--- a/ShootR/ShootR/ShootR.csproj
+++ b/ShootR/ShootR/ShootR.csproj
@@ -233,6 +233,9 @@
     <Content Include="Client\HUD\DeathScreen.ts" />
     <TypeScriptCompile Include="Client\Debug\UpdateRate.ts" />
     <TypeScriptCompile Include="Client\HUD\Chat.ts" />
+    <Content Include="Client\HUD\Chat.js">
+      <DependentUpon>Chat.ts</DependentUpon>
+    </Content>
     <TypeScriptCompile Include="Client\HUD\HUDManager.ts" />
     <Content Include="Client\HUD\ShipStatMonitor.ts" />
     <TypeScriptCompile Include="Client\HUD\LeaderboardManager.ts" />


### PR DESCRIPTION
This fixes a deployment problem where the chat.js file is missing on
publish. Including the js in the project ensures that the generated file
is included and HUD doesn't get busted.
